### PR TITLE
ci: EC2 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+# .github/workflows/deploy.yml
+
+name: Deploy Frontend to EC2
+
+on:
+  push:
+    branches:
+      - main # ← 원하시는 브랜치로 변경 가능
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18" # 또는 프로젝트에 맞는 버전
+
+      - name: Install and build frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build
+
+      - name: Deploy to EC2 via SCP
+        uses: appleboy/scp-action@v0.1.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          port: 3322
+          source: "frontend/build/*"
+          target: "/home/ubuntu/youtube-lecture/frontend/build"


### PR DESCRIPTION
GitHub Actions를 사용하여 프론트엔드 애플리케이션을 EC2 인스턴스에 자동으로 배포하는 워크플로우를 추가

주요 변경사항:
- GitHub Actions 워크플로우 파일(.github/workflows/deploy.yml) 추가
- main 브랜치에 푸시될 때 자동으로 EC2 인스턴스에 배포되도록 설정
- 빌드된 프론트엔드 파일을 SCP를 통해 EC2 서버로 전송
- HOST, KEY는 설정에 추가함